### PR TITLE
feat(sec-auth): Implement logout mutation that clears httpOnly token …

### DIFF
--- a/backend/src/__tests__/integration/cookieAuthE2E.test.ts
+++ b/backend/src/__tests__/integration/cookieAuthE2E.test.ts
@@ -375,7 +375,7 @@ describe('Cookie Auth E2E - Full HTTP Flow', () => {
       expect(setCookieHeader[0]).toMatch(/Max-Age=0|Expires=.*1970/i);
     });
 
-    it('should return UNAUTHENTICATED on me query after logout (simulated cleared cookie)', async () => {
+    it('should return auth error on me query without cookie', async () => {
       // After logout, browser won't send the cookie anymore
       // Simulate this by not sending any cookie
       const response = await request(app)
@@ -385,9 +385,44 @@ describe('Cookie Auth E2E - Full HTTP Flow', () => {
       expect(response.status).toBe(200);
       expect(response.body.errors).toBeDefined();
       // Shield returns NOT_AUTHORIZED for unauthenticated requests
-      expect(['UNAUTHENTICATED', 'NOT_AUTHORIZED', 'INTERNAL_SERVER_ERROR']).toContain(
+      expect(['UNAUTHENTICATED', 'NOT_AUTHORIZED']).toContain(
         response.body.errors[0].extensions.code
       );
+    });
+
+    it('should document token behavior after logout - cookie clearing only (no server-side blacklist)', async () => {
+      // First, verify we're authenticated with the token
+      const authCheck = await request(app)
+        .post('/graphql')
+        .set('Cookie', [`token=${validToken}`])
+        .send({ query: ME_QUERY });
+
+      expect(authCheck.status).toBe(200);
+      expect(authCheck.body.data?.me).toBeDefined();
+
+      // Now logout with the same token
+      const logoutResponse = await request(app)
+        .post('/graphql')
+        .set('Cookie', [`token=${validToken}`])
+        .send({ query: LOGOUT_MUTATION });
+
+      expect(logoutResponse.status).toBe(200);
+      expect(logoutResponse.body.data?.logout).toBe(true);
+
+      // Attempt me query reusing the same cookie header
+      // IMPORTANT: Current implementation only clears cookies (client-side)
+      // Without server-side token blacklist, the JWT remains valid until expiry
+      // In a real browser, Set-Cookie from logout clears the cookie so this scenario
+      // (client manually re-sending old token) wouldn't happen normally
+      const postLogoutResponse = await request(app)
+        .post('/graphql')
+        .set('Cookie', [`token=${validToken}`])
+        .send({ query: ME_QUERY });
+
+      expect(postLogoutResponse.status).toBe(200);
+      // Token is still cryptographically valid - this documents current behavior
+      // TODO: For true server-side invalidation, implement Redis token blacklist
+      expect(postLogoutResponse.body.data?.me).toBeDefined();
     });
 
     it('should require authentication to call logout', async () => {

--- a/backend/src/validation/shield.ts
+++ b/backend/src/validation/shield.ts
@@ -1,4 +1,5 @@
 import { shield, rule, allow } from 'graphql-shield';
+import { GraphQLError } from 'graphql';
 import { checkAuth, checkRole } from '../utils/authUtils';
 import { validateInput } from './middleware';
 import { registerSchema, loginSchema } from './schemas/user.schema';
@@ -14,7 +15,9 @@ const isAuthenticated = rule({ cache: 'contextual' })(
       checkAuth(context);
       return true;
     } catch (error) {
-      return false;
+      return new GraphQLError('Not authenticated', {
+        extensions: { code: 'UNAUTHENTICATED' }
+      });
     }
   }
 );
@@ -25,7 +28,9 @@ const isAdmin = rule({ cache: 'contextual' })(
       checkRole(context, 'ADMIN');
       return true;
     } catch (error) {
-      return false;
+      return new GraphQLError('Not authorized', {
+        extensions: { code: 'FORBIDDEN' }
+      });
     }
   }
 );


### PR DESCRIPTION
…cookie, and full E2E coverage (Closes #19)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended end-to-end tests for logout: verifies cookie is cleared, httpOnly/SameSite retained, logout requires authentication, and post-logout access is denied or documented.

* **Bug Fixes**
  * Authentication checks now surface proper GraphQL errors and standard error codes for unauthenticated/forbidden access, improving consistent API error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->