### PR TITLE
feat(sec-auth): adjust middleware to use cookie-based token + tests

### DIFF
--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -156,7 +156,7 @@ describe('Middleware - Admin Route Protection', () => {
   });
 
   describe('Expired/invalid token scenarios', () => {
-    it('redirects to /login when token is expired', () => {
+    it('redirects to /login with redirect param when token is expired', () => {
       const token = createMockToken({
         id: '1',
         email: 'admin@test.com',
@@ -168,22 +168,25 @@ describe('Middleware - Admin Route Protection', () => {
 
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toContain('/login');
+      expect(response.headers.get('location')).toContain('redirect=%2Fadmin');
     });
 
-    it('redirects to /login when token is malformed', () => {
-      const request = createMockRequest('/admin', 'invalid.token.here');
+    it('redirects to /login with redirect param when token is malformed', () => {
+      const request = createMockRequest('/admin/users', 'invalid.token.here');
       const response = middleware(request);
 
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toContain('/login');
+      expect(response.headers.get('location')).toContain('redirect=%2Fadmin%2Fusers');
     });
 
-    it('redirects to /login when token is empty string', () => {
-      const request = createMockRequest('/admin', '');
+    it('redirects to /login with redirect param when token is empty string', () => {
+      const request = createMockRequest('/admin/settings', '');
       const response = middleware(request);
 
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toContain('/login');
+      expect(response.headers.get('location')).toContain('redirect=%2Fadmin%2Fsettings');
     });
   });
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -33,6 +33,7 @@ export function middleware(request: NextRequest) {
       if (decoded.exp < currentTime) {
         console.log('Middleware: Token expired');
         const loginUrl = new URL('/login', request.url);
+        loginUrl.searchParams.set('redirect', request.nextUrl.pathname);
         return NextResponse.redirect(loginUrl);
       }
       
@@ -43,6 +44,7 @@ export function middleware(request: NextRequest) {
       
     } catch (error) {
       const loginUrl = new URL('/login', request.url);
+      loginUrl.searchParams.set('redirect', request.nextUrl.pathname);
       return NextResponse.redirect(loginUrl);
     }
   }


### PR DESCRIPTION
- Remove Authorization header fallback, now cookie-only
- Add 13 unit tests for middleware behaviors
- Test scenarios: no cookie, valid admin, non-admin, expired/invalid tokens
- Add mock cleanup between tests and improve type safety Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now consistently reads the token from a secure httpOnly cookie and ensures unauthenticated or expired sessions are redirected to login with the correct return path.

* **Tests**
  * Comprehensive unit tests for admin-route protection added, covering valid admin/non-admin tokens, expired/invalid/malformed/empty tokens, no-cookie flows, and redirect behavior for protected and unprotected routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->