### PR TITLE
fix(apod): allow nasa responses without url (Closes  #102)

### DIFF
--- a/_docs/featureBreakdown/v2.4.Apod.MD
+++ b/_docs/featureBreakdown/v2.4.Apod.MD
@@ -1168,7 +1168,7 @@ Request → Cache Check → (if hit) Response
 
 ---
 
-## Issue # 102: fix: nasa api res failed schema validation
+## ✅ Issue #102: fix: nasa api res failed schema validation
 
 ```bash
 }
@@ -1232,6 +1232,22 @@ This happens:
 ```bash
 <img width="461" height="544" alt="Image" src="https://github.com/user-attachments/assets/1e3e16fb-3203-4ff3-bc53-9853c3e08279" />
 ```
+
+### Fix ✅
+
+**Root cause:** `nasaApodRawSchema` required `url`, but NASA sometimes returns payloads where `url` is missing (observed on historical APOD dates). This caused Zod validation failure and surfaced as `BAD_GATEWAY` even though NASA returned `200`.
+
+**Solution:** Made `url` optional at the raw NASA schema validation layer. We still validate URL format when present.
+
+**Files Modified**
+| File | Change |
+|------|--------|
+| `backend/src/validation/schemas/apod.schema.ts` | `url` changed to `z.string().url().optional()` in `nasaApodRawSchema` |
+| `backend/src/__tests__/unit/apod.service.test.ts` | Added regression test for NASA payload missing `url` (still returns computed `apod_url`) |
+
+**Test Coverage**
+- `npm test -- --testPathPattern="apod.service"` ✅
+- `npm test -- --testPathPattern="apod"` ✅
 
 ---
 

--- a/backend/src/__tests__/unit/apod.service.test.ts
+++ b/backend/src/__tests__/unit/apod.service.test.ts
@@ -70,6 +70,23 @@ describe('APOD Service - fetchApod (Orchestrator)', () => {
       expect(mockFetchApodHtmlFallback).not.toHaveBeenCalled();
     });
 
+    it('should support NASA responses where url is missing (Issue #102)', async () => {
+      const responseWithoutUrl = {
+        ...mockApodResponse,
+        date: '2026-01-13',
+        url: undefined,
+      };
+
+      mockFetchApodFromApi.mockResolvedValueOnce(responseWithoutUrl);
+
+      const result = await fetchApod({ date: '2026-01-13', context: { userId: 'user-123' } });
+
+      expect(result.date).toBe('2026-01-13');
+      expect(result.url).toBeUndefined();
+      expect(result.apod_url).toBe('https://apod.nasa.gov/apod/ap260113.html');
+      expect(mockFetchApodHtmlFallback).not.toHaveBeenCalled();
+    });
+
     it('should pass date parameter to API', async () => {
       mockFetchApodFromApi.mockResolvedValueOnce(mockApodResponse);
 

--- a/backend/src/validation/schemas/apod.schema.ts
+++ b/backend/src/validation/schemas/apod.schema.ts
@@ -11,7 +11,7 @@ export const nasaApodRawSchema = z.object({
   media_type: z.enum(['image', 'video', 'other']),
   service_version: z.string(),
   title: z.string().min(1, 'Title is required'),
-  url: z.string().url('URL must be valid'),
+  url: z.string().url('URL must be valid').optional(),
   hdurl: z.string().url().optional(),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed APOD data loading failures when NASA API responses lack URL information. The system now gracefully generates an alternative URL format from the date when needed, improving data reliability for historical records.

* **Tests**
  * Added regression tests to ensure missing URL scenarios are properly handled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->