### PR TITLE
docs(stripe): add local setup guide, env comments, feature breakdown,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,42 @@ docker-compose up --build
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook signature secret *(reserved for phase 2)* |
 | `NEXT_PUBLIC_GRAPHQL_URL` | Frontend → API (defaults to `http://localhost:4000/graphql`) |
 
+### Stripe Local Setup
+
+The Stripe checkout flow requires a few one-time steps to run locally.
+
+**1. Get test API keys**
+
+Log in to the [Stripe Dashboard](https://dashboard.stripe.com) and toggle to **Test mode**.
+Navigate to [Developers → API keys](https://dashboard.stripe.com/test/apikeys) and copy the **Secret key** (`sk_test_...`).
+
+**2. Create test products and prices**
+
+Go to [Products](https://dashboard.stripe.com/test/products) in Test mode and create two products:
+
+| Product | Suggested price | `backend/.env` variable |
+|---|---|---|
+| Coffee | AUD 5 one-time | `STRIPE_COFFEE_PRICE_ID` |
+| Meeting | AUD 150 one-time | `STRIPE_MEETING_PRICE_ID` |
+
+After saving each product, copy its **Price ID** (`price_...`) into your `backend/.env`.
+
+**3. Set `FRONTEND_URL`**
+
+```bash
+# backend/.env
+FRONTEND_URL=http://localhost:3000   # no trailing slash
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_COFFEE_PRICE_ID=price_...
+STRIPE_MEETING_PRICE_ID=price_...
+```
+
+`FRONTEND_URL` is used to build the `cancel_url` and `success_url` sent to Stripe, so it must match the URL the frontend is actually running on. A trailing slash or extra path will cause redirect failures.
+
+**4. `STRIPE_WEBHOOK_SECRET` — Phase 2 (deferred)**
+
+Webhook fulfillment (persisting payment results to the database, sending confirmation emails) is planned for a future release. `STRIPE_WEBHOOK_SECRET` is wired into the config but **not required** to run the checkout flow today — leave it blank locally. When webhook support is added, create a webhook endpoint in the [Stripe Dashboard](https://dashboard.stripe.com/test/webhooks) pointing to `/api/stripe/webhook` and paste the signing secret into this variable.
+
 ---
 
 ## Testing

--- a/_docs/featureBreakdown/v3.1-stripe-payments.md
+++ b/_docs/featureBreakdown/v3.1-stripe-payments.md
@@ -131,14 +131,60 @@ Price IDs are injected from env:
 
 ---
 
+## Local Development Setup
+
+> **Goal:** a new engineer should be able to run the full checkout flow locally using only this guide.
+
+### 1. Get Stripe test keys
+
+1. Log in to [dashboard.stripe.com](https://dashboard.stripe.com) and switch to **Test mode** (toggle top-left).
+2. Go to **Developers → API keys**.
+3. Copy the **Secret key** (`sk_test_...`) → `STRIPE_SECRET_KEY` in `backend/.env`.
+
+### 2. Create test products
+
+Go to **Products** (still in Test mode) and create two one-time products:
+
+| Product | Price | Variable |
+|---------|-------|----------|
+| Coffee | AUD 5 | `STRIPE_COFFEE_PRICE_ID` |
+| Meeting | AUD 150 | `STRIPE_MEETING_PRICE_ID` |
+
+After saving each product, copy the **Price ID** (`price_...`) into `backend/.env`.
+
+### 3. Configure `FRONTEND_URL`
+
+```bash
+# backend/.env
+FRONTEND_URL=http://localhost:3000   # no trailing slash, no path suffix
+```
+
+This value is used to build `cancel_url` and `success_url` for Stripe sessions. A trailing slash or extra path will cause redirect failures in local and production.
+
+### 4. Start the stack
+
+```bash
+cd backend && npm run dev   # :4000
+cd frontend && npm run dev  # :3000
+```
+
+Click the floating **💳** button on the site → pick Coffee or Meeting → you'll be redirected to a Stripe-hosted test checkout. Use card `4242 4242 4242 4242` with any future expiry and CVC.
+
+### 5. `STRIPE_WEBHOOK_SECRET` — leave blank for now
+
+Webhook fulfillment is Phase 2 (see below). Leave `STRIPE_WEBHOOK_SECRET` empty locally — the checkout redirect flow works without it.
+
+---
+
 ## Current Limitations / Phase 2
 
-- Webhook fulfillment is not implemented yet (reserved in config as `STRIPE_WEBHOOK_SECRET`)
-- No payment confirmation persistence in DB yet
-- No admin reporting dashboard for support transactions yet
+- **[#152](https://github.com/lfariabr/luisfaria.dev/issues/152) — Analytics events** *(upcoming)*: `stripe_fab_opened`, `stripe_item_selected`, `stripe_checkout_started`, `stripe_checkout_error` are wired into the hook but the analytics provider integration needs validation across all environments.
+- **Webhook fulfillment** — `STRIPE_WEBHOOK_SECRET` is reserved in config. Phase 2 will add a `/api/stripe/webhook` endpoint to persist payment results and trigger confirmation emails via Resend. Deferred because it requires a publicly reachable URL (ngrok or production) and a more complex test harness.
+- **No payment persistence** — successful sessions are not stored in MongoDB yet (blocked by webhooks).
+- **No admin dashboard** — support transaction reporting is deferred to a later milestone.
 
 ---
 
 ## Release Notes Draft
 
-`v3.1.0` introduces Stripe support payments with two fixed purchase options (coffee/meeting), APOD-style floating CTA, hosted checkout redirect, and success/cancel return pages.
+`v3.1.0` introduces Stripe support payments with two fixed purchase options (coffee/meeting), APOD-style floating CTA, hosted checkout redirect, and success/cancel return pages. Webhook fulfillment and analytics event validation are tracked as follow-on issues (#152, phase 2).

--- a/_docs/releaseNotes/v.3.1.0_Stripe.md
+++ b/_docs/releaseNotes/v.3.1.0_Stripe.md
@@ -1,0 +1,100 @@
+# v3.1.0 — Stripe Payments (Coffee & Meeting) 💳
+
+**Release date:** 2026-03-13
+**Type:** Feature
+
+---
+
+## What's New
+
+### 💳 Stripe Checkout — Coffee & Meeting
+
+Visitors can now support the site directly. Two fixed purchase options are available from a global floating CTA:
+
+| Product | Price |
+|---------|-------|
+| ☕ Buy me a coffee | AUD 5 |
+| 📅 Book a meeting | AUD 150 |
+
+#### How it works
+
+1. Visitor clicks the **💳 StripeFab** (floating button, bottom-right — stacks above the APOD button).
+2. A transparent **StripeDialog** appears with product options.
+3. Selecting a product fires the `createCheckoutSession` GraphQL mutation → backend creates a Stripe-hosted session.
+4. User is redirected to the Stripe checkout page.
+5. On completion → `/payment/success` (with optional "Return to page" button).
+6. On cancel or back-button → `/payment/cancel` (restores the original page).
+
+#### Security & validation
+
+- `STRIPE_SECRET_KEY` is backend-only; never sent to the client.
+- `returnUrl` origin is validated server-side against `FRONTEND_URL` — mismatched origins are rejected with `BAD_USER_INPUT` (prevents open-redirect attacks).
+- Mutation is intentionally public (no auth required for support flow).
+- Graceful degradation: if `STRIPE_SECRET_KEY` is missing, service logs a warning and returns 503 — no crash.
+
+---
+
+## Environment Variables
+
+See `backend/.env.example` for full comments and setup instructions.
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `FRONTEND_URL` | ✅ | Base URL, no trailing slash (e.g. `http://localhost:3000`) |
+| `STRIPE_SECRET_KEY` | ✅ | `sk_test_...` for dev, `sk_live_...` for prod |
+| `STRIPE_COFFEE_PRICE_ID` | ✅ | `price_...` from Stripe Dashboard |
+| `STRIPE_MEETING_PRICE_ID` | ✅ | `price_...` from Stripe Dashboard |
+| `STRIPE_WEBHOOK_SECRET` | ⏳ Phase 2 | Leave blank locally — not needed for redirect flow |
+
+---
+
+## Upcoming
+
+- **[#152](https://github.com/lfariabr/luisfaria.dev/issues/152) — Stripe analytics events**: `stripe_fab_opened`, `stripe_item_selected`, `stripe_checkout_started`, `stripe_checkout_error` are wired into the hook and need full validation across environments.
+- **Phase 2 — Webhook fulfillment**: persist payment results to MongoDB, send confirmation emails via Resend, add `/api/stripe/webhook` endpoint. Requires `STRIPE_WEBHOOK_SECRET` and a publicly accessible URL.
+- **Phase 2 — Admin dashboard**: transaction reporting for support payments.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/services/stripe.ts` | New — Stripe client, `createCheckoutSession`, `getCheckoutSessionStatus`, origin validation |
+| `backend/src/resolvers/stripe/mutations.ts` | New — `createCheckoutSession` resolver with `createErrorHandler` |
+| `backend/src/resolvers/stripe/queries.ts` | New — `getCheckoutSession` resolver |
+| `backend/src/schemas/types/stripeTypes.ts` | New — GraphQL types (`CheckoutInput`, `CheckoutSession`, `CheckoutSessionStatus`) |
+| `backend/src/validation/schemas/checkout.schema.ts` | New — Zod validation for checkout input |
+| `backend/src/validation/shield.ts` | Updated — `createCheckoutSession: allow` (public mutation) |
+| `backend/src/resolvers/index.ts` | Updated — Stripe resolvers registered |
+| `backend/src/schemas/typeDefs.ts` | Updated — Stripe types imported |
+| `backend/src/config/config.ts` | Updated — `stripeSecretKey`, `stripeCoffeePriceId`, `stripeMeetingPriceId`, `stripeWebhookSecret`, `frontendUrl` |
+| `frontend/src/lib/graphql/mutations/stripe.mutations.ts` | New — `CREATE_CHECKOUT_SESSION` mutation |
+| `frontend/src/lib/graphql/queries/stripe.queries.ts` | New — `GET_CHECKOUT_SESSION` query |
+| `frontend/src/lib/graphql/types/stripe.types.ts` | New — TypeScript types |
+| `frontend/src/lib/hooks/useStripeCheckout.ts` | New — checkout hook; captures `returnUrl`, fires analytics, redirects |
+| `frontend/src/components/stripe/StripeFab.tsx` | New — floating action button |
+| `frontend/src/components/stripe/StripeDialog.tsx` | New — product selection dialog |
+| `frontend/src/app/payment/success/page.tsx` | New — post-checkout success page with optional return button |
+| `frontend/src/app/payment/cancel/page.tsx` | New — post-checkout cancel page |
+| `frontend/src/app/layout.tsx` | Updated — `StripeFab` mounted globally |
+| `backend/.env.example` | Updated — Stripe vars with inline comments and setup instructions |
+| `README.md` | Updated — Stripe setup section (test keys, price IDs, phase-2 note) |
+| `backend/src/__tests__/unit/stripe.service.test.ts` | New — 14 service tests |
+| `backend/src/__tests__/unit/stripe.mutations.test.ts` | Updated — resolver tests incl. returnUrl + INVALID_RETURN_URL |
+| `frontend/src/__tests__/lib/hooks/useStripeCheckout.test.tsx` | New — 9 hook tests |
+| `frontend/src/__tests__/components/Stripe.test.tsx` | Updated — loading state, error alert, meeting product tests |
+
+---
+
+## TL;DR Changelog
+
+```
+feat(stripe): add coffee/meeting checkout flow with APOD-style FAB (#155)
+feat(stripe): pass returnUrl from frontend and restore original page on cancel/success (#158)
+fix(stripe): validate returnUrl origin server-side to prevent open redirect (#159)
+test(stripe): cover checkout service, resolver, hook, and FAB/dialog (#160)
+docs(stripe): add local setup guide, env comments, phase-2 webhook plan (#154)
+```
+
+**Full Changelog**: https://github.com/lfariabr/luisfaria.dev/compare/v2.9.94...v3.1.0

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,9 +34,30 @@ NASA_API_KEY=your_nasa_api_key
 # Sentry (error tracking)
 SENTRY_DSN=sentry_key
 
-# Base URL of the frontend — no trailing slash, no path suffix (e.g. https://luisfaria.dev or http://localhost:3000)
+# -----------------------------------------------------------------------
+# Stripe Payments
+# -----------------------------------------------------------------------
+# Base URL of the frontend — no trailing slash, no path suffix.
+# Used to build cancel_url and success_url for Stripe checkout sessions.
+# Dev example:  http://localhost:3000
+# Prod example: https://luisfaria.dev
 FRONTEND_URL=http://localhost:3000
-STRIPE_SECRET_KEY=xxxx
+
+# Stripe secret key — backend only, never expose to the client.
+# Find it at: https://dashboard.stripe.com/apikeys
+# Use sk_test_... for local development; sk_live_... for production.
+STRIPE_SECRET_KEY=sk_test_xxxx
+
+# Stripe webhook signing secret — reserved for Phase 2 (fulfillment).
+# NOT required to run the checkout flow today; leave blank locally.
+# When you add webhook support: https://dashboard.stripe.com/webhooks → "Add endpoint" → copy signing secret.
 STRIPE_WEBHOOK_SECRET=whsec_xxxx
+
+# Stripe Price IDs for each product.
+# Create test prices at: https://dashboard.stripe.com/test/products
+#   1. Create a product (e.g. "Coffee")
+#   2. Add a one-time price (e.g. AUD 5)
+#   3. Copy the Price ID (starts with price_)
+# Use price_test_... IDs for local/test; price_... IDs for live.
 STRIPE_COFFEE_PRICE_ID=price_xxxx
 STRIPE_MEETING_PRICE_ID=price_xxxx


### PR DESCRIPTION
… and release notes (#154)

- backend/.env.example: annotate all Stripe vars with where to find them, test vs live key prefixes, and phase-2 webhook note
- README.md: add Stripe Local Setup section (test keys, price IDs, FRONTEND_URL warning, phase-2 webhook deferred rationale)
- _docs/featureBreakdown/v3.1-stripe-payments.md: add Local Development Setup walkthrough and updated Phase 2 / limitations section with reference to upcoming issue #152
- _docs/releaseNotes/v.3.1.0_Stripe.md: new release note covering full v3.1 scope, env var table, upcoming issues (#152, phase 2), and complete files-changed log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive local development setup guides for Stripe payments integration.
  * Included step-by-step instructions for obtaining test API keys and configuring test products.
  * Provided environment variable configuration examples and test card usage guidance.
  * Documented current limitations and upcoming Phase 2 enhancements for payment processing and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->