### PR TITLE
fix(auth): align password hint with actual validation rules (closes #…

### DIFF
--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -166,7 +166,7 @@ export default function RegisterPage() {
                 required
               />
               <p className="text-xs text-muted-foreground">
-                Password must be at least 8 characters long
+                Must be 8+ characters with uppercase, lowercase, number, and special character (@$!%*?&)
               </p>
             </div>
             


### PR DESCRIPTION
…166)

The hint said "at least 8 characters" but validation enforces uppercase, lowercase, digit, and special char too — causing silent submit failures. Updated hint to reflect the full requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified password requirements guidance in the registration form to specify minimum 8 characters with uppercase, lowercase, number, and special character (@$!%*?&).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->