### PR TITLE
fix(layout): hide APOD and Stripe FABs on /notes pages

### DIFF
--- a/frontend/src/components/apod/ApodFab.tsx
+++ b/frontend/src/components/apod/ApodFab.tsx
@@ -16,7 +16,7 @@ export function ApodFab() {
   const pathname = usePathname();
   const [open, setOpen] = React.useState(false);
 
-  if (pathname.startsWith('/notes')) return null;
+  if (pathname && (pathname === '/notes' || pathname.startsWith('/notes/'))) return null;
 
   return (
     <>

--- a/frontend/src/components/stripe/StripeFab.tsx
+++ b/frontend/src/components/stripe/StripeFab.tsx
@@ -17,7 +17,7 @@ export function StripeFab() {
   const pathname = usePathname();
   const [open, setOpen] = React.useState(false);
 
-  if (pathname.startsWith('/notes')) return null;
+  if (pathname && (pathname === '/notes' || pathname.startsWith('/notes/'))) return null;
 
   const handleOpen = () => {
     setOpen(true);


### PR DESCRIPTION
## Summary
- Added `usePathname()` to `ApodFab` and `StripeFab`
- Both return `null` early when pathname starts with `/notes`, hiding them on all `/notes*` routes

## Test plan
- [ ] Navigate to `/notes` — both FABs should be invisible
- [ ] Navigate to `/`, `/projects`, `/articles` — both FABs still visible
- [ ] Frontend tests pass: `cd frontend && npm test`

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Floating action buttons (APOD and Stripe) are now hidden when viewing the notes section and its subpages, preventing their dialogs from appearing on those routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->