### PR TITLE
fix: allow notes form saves without hidden content

### DIFF
--- a/frontend/src/__tests__/components/NoteForm.test.tsx
+++ b/frontend/src/__tests__/components/NoteForm.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { NoteForm } from '@/components/notes/NoteForm';
+
+describe('NoteForm', () => {
+  it('omits empty hidden content on submit', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    render(<NoteForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create note' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Weekly update',
+          content: undefined,
+          periodType: 'WEEKLY',
+          accomplishments: [],
+          nextPlans: [],
+          tags: [],
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/components/notes/NoteForm.tsx
+++ b/frontend/src/components/notes/NoteForm.tsx
@@ -45,9 +45,11 @@ export function NoteForm({ note, loading = false, onSubmit }: NoteFormProps) {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     const defaultTitle = periodType === 'MONTHLY' ? 'Monthly update' : 'Weekly update';
+    const normalizedContent = content.trim() || undefined;
+
     await onSubmit({
       title: title.trim() || defaultTitle,
-      content,
+      content: normalizedContent,
       date: `${date}T00:00:00.000Z`,
       periodType,
       accomplishments: parseCsv(accomplishments),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed note form to properly handle empty content by omitting it from submissions instead of sending blank values.

* **Tests**
  * Added test coverage for note form submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->